### PR TITLE
l10n support, CDN replaced with npm-asset/flatpickr

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ echo $form->field($model, 'date')->widget(
         'dateFormat' => 'F j, Y H:i',
         'altInput' => true,
         'altFormat' => 'F j, Y',
+        'locale' => 'ru',
     ]
 ]);
 ?>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,14 @@
     "source": "https://github.com/2amigos/yii2-flatpickr-widget"
   },
   "require": {
+    "npm-asset/flatpickr": "^4.6.13"
   },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    }
+  ],
   "require-dev": {
   },
   "autoload": {

--- a/src/FlatpickrAsset.php
+++ b/src/FlatpickrAsset.php
@@ -6,15 +6,19 @@ use yii\web\JqueryAsset;
 
 class FlatpickrAsset extends \yii\web\AssetBundle
 {
+    public $sourcePath = '@npm/flatpickr';
+
     public $js = [
-        '//cdn.jsdelivr.net/npm/flatpickr',
+        'dist/flatpickr.min.js',
     ];
 
     public $css = [
-        '//cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
+        'dist/flatpickr.min.css',
     ];
 
     public $depends = [
         JqueryAsset::class,
     ];
+
+
 }

--- a/src/FlatpickrLanguageAsset.php
+++ b/src/FlatpickrLanguageAsset.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace cgsmith\flatpickr;
+
+class FlatpickrLanguageAsset extends \yii\web\AssetBundle
+{
+    public $sourcePath = '@npm/flatpickr';
+
+    public $locale;
+
+    public $depends = [
+        FlatpickrAsset::class,
+    ];
+
+    public function registerAssetFiles($view)
+    {
+        $this->js[] = 'dist/l10n/' . $this->locale . '.js';
+        parent::registerAssetFiles($view);
+    }
+}

--- a/src/FlatpickrWidget.php
+++ b/src/FlatpickrWidget.php
@@ -56,6 +56,10 @@ class FlatpickrWidget extends InputWidget
 
         FlatpickrAsset::register($this->getView());
         $view = $this->getView();
+        if (isset($this->flatpickrConfig['locale'])) {
+            $assetBundle = FlatpickrLanguageAsset::register($view);
+            $assetBundle->locale = $this->flatpickrConfig['locale'];
+        }
         $view->registerJs('
             // cgsmith-flatpickr-widget
             $(\'.date-' . $this->attribute.'\').flatpickr('


### PR DESCRIPTION
Added l10n support, third party CDN replaced with npm-asset/flatpickr